### PR TITLE
Clickable cards

### DIFF
--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -1,3 +1,15 @@
-.card:nth-child(3n+1){
+.card:nth-child(3n+1) {
   clear:left
+}
+
+.link-anchor {
+  position: relative;
+}
+
+a.card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
 }

--- a/app/assets/stylesheets/_cards.scss
+++ b/app/assets/stylesheets/_cards.scss
@@ -6,7 +6,7 @@
   position: relative;
 }
 
-a.card {
+.clickable-card {
   position: absolute;
   top: 0;
   left: 0;

--- a/app/views/lists/_index.html.erb
+++ b/app/views/lists/_index.html.erb
@@ -3,7 +3,7 @@
     <div class="col-md-4 card">
       <div class="panel panel-default">
         <div class="panel-body">
-           <% if user_signed_in? %>
+          <% if user_signed_in? %>
             <div class="row">
               <div class="col-md-12">
                 <%= render partial: 'lists/toggle_pin', locals: { list: list } %>

--- a/app/views/lists/_index.html.erb
+++ b/app/views/lists/_index.html.erb
@@ -21,7 +21,7 @@
             Tags:<i><%= list.tag_list %></i></br>
             Updated On: <%= list.updated_at %></br>
           </small>
-          <%= link_to '', list, class: "card"%>
+          <%= link_to '', list, class: "clickable-card"%>
         </div>
       </div>
     </div>

--- a/app/views/lists/_index.html.erb
+++ b/app/views/lists/_index.html.erb
@@ -21,6 +21,7 @@
             Tags:<i><%= list.tag_list %></i></br>
             Updated On: <%= list.updated_at %></br>
           </small>
+          <%= link_to '', list, class: "card"%>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Issue:** List names are hard to click on mobile

**Solution:** Make the entire card clickable.

**Complications:** I'm not sure if this fucks with screen readers for the blind. I tried to position the anchor element behind everything else, so a screen reader should be able to read individual items, but I don't have one on me to test with.

Also, the site is just unreadably tiny on mobile. We've gotta fix that. I've made Issue #69 for that.
