### PR TITLE
Allow linebreaks in comments

### DIFF
--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,7 +3,7 @@
     Added by <strong><%= link_to comment.user.username, user_profile_path(comment.user.username) %></strong> on <%= l(comment.created_at, format: '%B, %d %Y %H:%M:%S') %>
   </p>
 
-  <p><%= comment.content %></p>
+  <p><%= simple_format(comment.content) %></p>
   <ul>
     <li><%= render 'votes/toggle_like', votable: comment %></li>
     <% if current_user %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -3,7 +3,7 @@
     Added by <strong><%= link_to comment.user.username, user_profile_path(comment.user.username) %></strong> on <%= l(comment.created_at, format: '%B, %d %Y %H:%M:%S') %>
   </p>
 
-  <p><%= simple_format(comment.content) %></p>
+  <p><%= simple_format(comment.content, {}, sanitize: true) %></p>
   <ul>
     <li><%= render 'votes/toggle_like', votable: comment %></li>
     <% if current_user %>


### PR DESCRIPTION
**Problem:** Can't see linebreaks in comments

**Solution:** Show line breaks

**Complications:** Not really sure what else `#simple_format` does...

**Changelog:** 
- Allow linebreaks with `#simple_format`
