### PR TITLE
Adds pry-rails for debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
 end
 
 group :development do
+  gem 'pry-rails'
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
   gem 'web-console'
   gem 'listen', '~> 3.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
     closure_tree (6.1.0)
       activerecord (>= 4.1.0)
       with_advisory_lock (>= 3.0.0)
+    coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.1.x)
@@ -102,6 +103,12 @@ GEM
     orm_adapter (0.5.0)
     pg (0.18.4)
     pkg-config (1.1.7)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-rails (0.3.4)
+      pry (>= 0.9.10)
     puma (3.4.0)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -142,6 +149,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    slop (3.6.0)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
@@ -190,6 +198,7 @@ DEPENDENCIES
   jquery-rails (~> 4.1.1)
   listen (~> 3.0.5)
   pg (~> 0.18)
+  pry-rails
   puma (~> 3.0)
   rails (>= 5.0.0, < 5.1)
   sass-rails (~> 5.0)
@@ -203,4 +212,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.0
+   1.13.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       - DOCKERIZED=true
     env_file:
       - '.env'
+    tty: true
+    stdin_open: true
   postgres:
     image: postgres:9.5
     ports:


### PR DESCRIPTION
**Problem:** None, really, I just miss pry. And while the web console is alright, pry is way better.

**Solution:** Add `pry-rails`

**Complications:** None?

**Usage:** 

https://gist.github.com/briankung/ebfb567d149209d2d308576a6a34e5d8 (copied below)

---

First, add pry-rails to your Gemfile:  
https://github.com/rweng/pry-rails

``` ruby
gem 'pry-rails', group: :development
```

Then you'll want to rebuild your Docker container to install the gems

``` sh
docker-compose build
```

You should now be able to add a break point anywhere in your code

``` ruby
binding.pry
```

The problem is that Docker just kind of ignores it and moves on. In order to actually halt execution and use pry as normal, you have to these options to docker-compose.yml:

``` yaml
app:
  tty: true
  stdin_open: true
```

Source: http://stackoverflow.com/a/37264588/1042144

The next time `binding.pry` is executed, the process should halt and display an IRB-like console on the rails server screen. But you still can't use it directly. You have to attach a terminal to the docker container.

In order to attach to a docker container, you need to know what its ID is. Use `docker ps` to get a list of the running containers and their ids.

``` sh
docker ps
```

Source: https://www.liquidweb.com/kb/how-to-list-and-attach-to-docker-containers/

Then you can use the numeric ID to attach to the docker instance:

``` sh
docker attach 75cde1ab8133
```

It may not immediately show a rails console, but start typing and it should appear. If you keep this attached, it should show the rails console prompt the next time you hit the pry breakpoint.

Neat things you should try with pry:

``` ruby
show-routes
show-models
show-source edit  # If you're in a controller, for instance

cd                # Navigate up or down class hierarchies. try `cd BasicObject`
ls                # Check out what's inside of a class - variables, etc.
```

And of course you can access local variables just by typing their names.

``` ruby
params
#=> <ActionController::Parameters {"controller"=>"lists", "action"=>"index"} permitted: false>
```

To end your pry-rails session, you can type exit as you would exit any irb instance.

``` ruby
exit
```

However, this does not detach the terminal from the docker container. This can be useful to continue debugging.

Additionally, I had two terminals open, one to review the server log and one to attach to my container to use pry-rails, but docker will timeout the server log while the attached terminal  continues to run the rails server process. I'm okay with that - I can just leave the terminal attached. However, if you want to detach from the container without ending the process, you need to press ctrl-p + ctrl-q.

Source: http://stackoverflow.com/a/19689048/1042144
