### PR TITLE
Author names

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.MD
+++ b/.github/PULL_REQUEST_TEMPLATE.MD
@@ -1,9 +1,9 @@
-**Problem:** 
+**Problem:**
 
-**Solution:** 
+**Solution:**
 
-**Complications:** 
+**Complications:**
 
-**Changelog:** 
+**Feature Changelog:**
 
 - Enter high level description of changes here.

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -39,6 +39,6 @@ class PapersController < ApplicationController
         bias_list: [],
         methodology_list: [],
         links_attributes: [:id, :url],
-        authors_attributes: [:id, :first_name, :last_name])
+        authors_attributes: [:id, :given_name, :family_name])
     end
 end

--- a/app/controllers/papers_controller.rb
+++ b/app/controllers/papers_controller.rb
@@ -35,6 +35,6 @@ class PapersController < ApplicationController
     def paper_params
       params.require(:paper).permit(
         :title, :abstract, :link, :doi, :pubmed_id, :published_at, :publication,
-        :tag_list, bias_list: [], methodology_list: [], authors_attributes: [:id, :name])
+        :tag_list, bias_list: [], methodology_list: [], authors_attributes: [:id, :first_name, :last_name])
     end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,6 +1,11 @@
 class Author < ApplicationRecord
   has_and_belongs_to_many :papers
-  validates :name, uniqueness: { case_sensitive: false }, presence: true
+  validates :last_name,
+    presence: true,
+    uniqueness: {
+      case_sensitive: false,
+      scope: :first_name
+    }
 
   def full_name
     "#{first_name} #{last_name}"

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,4 +1,8 @@
 class Author < ApplicationRecord
   has_and_belongs_to_many :papers
   validates :name, uniqueness: { case_sensitive: false }, presence: true
+
+  def full_name
+    "#{first_name} #{last_name}"
+  end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -5,6 +5,6 @@ class Author < ApplicationRecord
   validates :full_name, presence: true, uniqueness: { case_sensitive: false }
 
   def set_full_name
-    self.full_name = "#{first_name} #{last_name}"
+    self.full_name = "#{given_name} #{family_name}"
   end
 end

--- a/app/models/author.rb
+++ b/app/models/author.rb
@@ -1,13 +1,10 @@
 class Author < ApplicationRecord
   has_and_belongs_to_many :papers
-  validates :last_name,
-    presence: true,
-    uniqueness: {
-      case_sensitive: false,
-      scope: :first_name
-    }
 
-  def full_name
-    "#{first_name} #{last_name}"
+  before_validation :set_full_name
+  validates :full_name, presence: true, uniqueness: { case_sensitive: false }
+
+  def set_full_name
+    self.full_name = "#{first_name} #{last_name}"
   end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -15,9 +15,9 @@ class List < ApplicationRecord
   validates :name,
             presence: true,
             uniqueness: {
-                scope: :user,
-                case_sensitive: false,
-                message: "must be unique for lists you own."
+              scope: :user,
+              case_sensitive: false,
+              message: "must be unique for lists you own."
             }
 
   def to_slug

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -10,7 +10,7 @@ class Paper < ApplicationRecord
   has_many :links, dependent: :destroy
   has_many :api_import_responses, dependent: :destroy
 
-  accepts_nested_attributes_for :authors, reject_if: proc { |attributes| attributes['last_name'].blank? }
+  accepts_nested_attributes_for :authors, reject_if: proc { |attributes| attributes['family_name'].blank? }
   accepts_nested_attributes_for :links
   validates_associated :links
   validates :title, presence: true
@@ -63,7 +63,7 @@ class Paper < ApplicationRecord
 
   def autosave_associated_records_for_authors
     self.authors = authors.map do |author|
-      Author.find_or_create_by first_name: author.first_name, last_name: author.last_name
+      Author.find_or_create_by given_name: author.given_name, family_name: author.family_name
     end
   end
 

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -62,7 +62,7 @@ class Paper < ApplicationRecord
 
   def autosave_associated_records_for_authors
     self.authors = authors.map do |author|
-      Author.find_or_create_by name: author.name
+      Author.find_or_create_by first_name: author.first_name, last_name: author.last_name
     end
   end
 

--- a/app/models/paper.rb
+++ b/app/models/paper.rb
@@ -10,7 +10,7 @@ class Paper < ApplicationRecord
   has_many :links, dependent: :destroy
   has_many :api_import_responses, dependent: :destroy
 
-  accepts_nested_attributes_for :authors, reject_if: proc { |attributes| attributes['name'].blank? }
+  accepts_nested_attributes_for :authors, reject_if: proc { |attributes| attributes['last_name'].blank? }
   accepts_nested_attributes_for :links
   validates :title, presence: true
   validate :allowed_biases, :allowed_methodologies

--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -45,7 +45,7 @@ class Crossref
         authors_attributes: lambda do |data|
           if (authors = data.dig 'message', 'author')
             authors.map do |author|
-              {name: author.values_at('given', 'family').join(' ')}
+              {first_name: author['given'], last_name: author['family']}
             end
           else
             []

--- a/app/models/services/crossref/resource.rb
+++ b/app/models/services/crossref/resource.rb
@@ -45,7 +45,7 @@ class Crossref
         authors_attributes: lambda do |data|
           if (authors = data.dig 'message', 'author')
             authors.map do |author|
-              {first_name: author['given'], last_name: author['family']}
+              {given_name: author['given'], family_name: author['family']}
             end
           else
             []

--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -25,7 +25,7 @@ class Pubmed
         title:              lambda {|data| data.css('ArticleTitle').text },
         publication:        lambda {|data| data.css('Journal Title').text },
         doi:                lambda {|data| data.css('ArticleId[IdType=doi]').text },
-        pubmed_id:          lambda {|data| data.css('PMID').text },
+        pubmed_id:          lambda {|data| data.css('ArticleIdList ArticleId[IdType=pubmed]').text },
         abstract:           lambda {|data| data.css('AbstractText').map(&:text).join("\n\n") },
         published_at:       lambda {|data| Date.parse data.css('PubDate').map(&:text).join(' ') },
         authors_attributes: lambda do |data|

--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -31,7 +31,7 @@ class Pubmed
         authors_attributes: lambda do |data|
           authors = data.css('AuthorList Author')
           authors.map do |author|
-            {name: [author.css("ForeName"), author.css("LastName")].join(' ')}
+            {first_name: author.css("ForeName"), last_name: author.css("LastName")}
           end
         end
       }

--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -31,7 +31,7 @@ class Pubmed
         authors_attributes: lambda do |data|
           authors = data.css('AuthorList Author')
           authors.map do |author|
-            {first_name: author.css("ForeName").text, last_name: author.css("LastName").text}
+            {given_name: author.css("ForeName").text, family_name: author.css("LastName").text}
           end
         end
       }

--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -31,7 +31,7 @@ class Pubmed
         authors_attributes: lambda do |data|
           authors = data.css('AuthorList Author')
           authors.map do |author|
-            {first_name: author.css("ForeName"), last_name: author.css("LastName")}
+            {first_name: author.css("ForeName").text, last_name: author.css("LastName").text}
           end
         end
       }

--- a/app/views/papers/_form.html.erb
+++ b/app/views/papers/_form.html.erb
@@ -22,16 +22,16 @@
 
     <%= f.fields_for :authors, paper.authors do |a| %>
       <div class="form-group">
-        <%= a.label :first_name, 'Author First Name', class: "col-md-2 control-label" %>
+        <%= a.label :given_name, 'Author Given Name', class: "col-md-2 control-label" %>
         <div class="col-md-10">
-          <%= a.text_field :first_name, class: "form-control"  %>
+          <%= a.text_field :given_name, class: "form-control"  %>
         </div>
       </div>
 
       <div class="form-group">
-        <%= a.label :last_name, 'Author Last Name', class: "col-md-2 control-label" %>
+        <%= a.label :family_name, 'Author Family Name', class: "col-md-2 control-label" %>
         <div class="col-md-10">
-          <%= a.text_field :last_name, class: "form-control"  %>
+          <%= a.text_field :family_name, class: "form-control"  %>
         </div>
       </div>
     <% end %>

--- a/app/views/papers/_form.html.erb
+++ b/app/views/papers/_form.html.erb
@@ -22,9 +22,16 @@
 
     <%= f.fields_for :authors, paper.authors do |a| %>
       <div class="form-group">
-        <%= a.label :name, 'Author Full Name', class: "col-md-2 control-label" %>
+        <%= a.label :first_name, 'Author First Name', class: "col-md-2 control-label" %>
         <div class="col-md-10">
-          <%= a.text_field :name, class: "form-control"  %>
+          <%= a.text_field :first_name, class: "form-control"  %>
+        </div>
+      </div>
+
+      <div class="form-group">
+        <%= a.label :last_name, 'Author Last Name', class: "col-md-2 control-label" %>
+        <div class="col-md-10">
+          <%= a.text_field :last_name, class: "form-control"  %>
         </div>
       </div>
     <% end %>

--- a/app/views/papers/_metadata.html.erb
+++ b/app/views/papers/_metadata.html.erb
@@ -1,5 +1,5 @@
 <small>
-  <%= paper.authors.map(&:name).join(', ') %>
+  <%= paper.authors.map(&:full_name).join(', ') %>
   <i>
     <%= content_tag(:span, "in #{paper.publication}", class: 'publication') if paper.publication.present? %>
     <%= "(#{paper.published_at})" if paper.published_at.present? %>

--- a/app/views/papers/show.html.erb
+++ b/app/views/papers/show.html.erb
@@ -5,7 +5,7 @@
 
 <p>
   <strong>Authors:</strong>
-  <%= @paper.authors.map(&:name).join(', ') %>
+  <%= @paper.authors.map(&:full_name).join(', ') %>
 </p>
 
 <p>

--- a/db/migrate/20161112012014_split_author_names.rb
+++ b/db/migrate/20161112012014_split_author_names.rb
@@ -1,0 +1,6 @@
+class SplitAuthorNames < ActiveRecord::Migration[5.0]
+  def change
+    add_column :authors, :first_name, :text
+    add_column :authors, :last_name, :text
+  end
+end

--- a/db/migrate/20161112194756_modify_data_convert_to_name_parts.rb
+++ b/db/migrate/20161112194756_modify_data_convert_to_name_parts.rb
@@ -1,0 +1,17 @@
+class ModifyDataConvertToNameParts < ActiveRecord::Migration[5.0]
+  def up
+    Author.find_each(batch_size: 50) do |author|
+      name_parts = author.name.split(' ')
+      author.last_name = name_parts.pop
+      author.first_name = name_parts.join(' ')
+      author.save
+    end
+  end
+
+  def down
+    Author.find_each(batch_size: 50) do |author|
+      author.name = "#{author.first_name} #{author.last_name}"
+      author.save
+    end
+  end
+end

--- a/db/migrate/20161112195802_remove_name_from_authors.rb
+++ b/db/migrate/20161112195802_remove_name_from_authors.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromAuthors < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :authors, :name, :text
+  end
+end

--- a/db/migrate/20161114011810_add_full_name_to_authors.rb
+++ b/db/migrate/20161114011810_add_full_name_to_authors.rb
@@ -1,0 +1,7 @@
+class AddFullNameToAuthors < ActiveRecord::Migration[5.0]
+  def change
+    enable_extension :citext
+    add_column :authors, :full_name, :citext
+    add_index :authors, :full_name, unique: true
+  end
+end

--- a/db/migrate/20161115161211_change_author_name_parts.rb
+++ b/db/migrate/20161115161211_change_author_name_parts.rb
@@ -1,0 +1,6 @@
+class ChangeAuthorNameParts < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :authors, :first_name, :given_name
+    rename_column :authors, :last_name, :family_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161112195802) do
+ActiveRecord::Schema.define(version: 20161114011810) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "citext"
 
   create_table "api_import_responses", force: :cascade do |t|
     t.text     "xml"
@@ -31,6 +32,8 @@ ActiveRecord::Schema.define(version: 20161112195802) do
     t.datetime "updated_at", null: false
     t.text     "first_name"
     t.text     "last_name"
+    t.citext   "full_name"
+    t.index ["full_name"], name: "index_authors_on_full_name", unique: true, using: :btree
   end
 
   create_table "authors_papers", id: false, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114011810) do
+ActiveRecord::Schema.define(version: 20161115161211) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,10 +28,10 @@ ActiveRecord::Schema.define(version: 20161114011810) do
 
   create_table "authors", force: :cascade do |t|
     t.string   "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.text     "first_name"
-    t.text     "last_name"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.text     "given_name"
+    t.text     "family_name"
     t.citext   "full_name"
     t.index ["full_name"], name: "index_authors_on_full_name", unique: true, using: :btree
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161030205356) do
+ActiveRecord::Schema.define(version: 20161112195802) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,10 +26,11 @@ ActiveRecord::Schema.define(version: 20161030205356) do
   end
 
   create_table "authors", force: :cascade do |t|
-    t.string   "name"
     t.string   "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text     "first_name"
+    t.text     "last_name"
   end
 
   create_table "authors_papers", id: false, force: :cascade do |t|


### PR DESCRIPTION
**Problem:** We didn't support first and last names. This would make it very difficult to consolidate author names in the future.

**Solution:** Split author names

**Complications:**
- https://www.kalzumeus.com/2010/06/17/falsehoods-programmers-believe-about-names/
- Also, I'm not happy about having to use the `citext` extension to enforce case insensitive uniqueness on author full name. I might investigate this more before merging.