### PR TITLE
Enable web console all the time in development

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,5 +36,6 @@
       <p class="alert alert-danger"><%= alert %></p>
     <% end %>
     <%= yield %>
+    <%= console if Rails.env.development? %>
   </body>
 </html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,4 +56,6 @@ Rails.application.configure do
   if ENV['DOCKERIZED'] == 'true'
     config.web_console.whitelisted_ips = ENV['DOCKER_HOST_IP']
   end
+
+  config.web_console.automount = true
 end


### PR DESCRIPTION
**Problem:** Booting up rails console is annoying and not all users on all OSes get web console

**Solution:** Enable web console all the time in development

**Changelog:** 

- Enable web console all the time in development

