### PR TITLE
Lists fix

### DIFF
--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -20,9 +20,11 @@ class ListsController < ApplicationController
   # POST /lists.json
   def create
     @list = current_user.lists.build(list_params)
+    member = User.find_by username: params[:list].delete(:members)
 
     respond_to do |format|
       if @list.save
+        @list.members.add(member, role: :contributor) if member
         current_user.homepage.lists << @list
         format.html { redirect_to user_list_path(@list.owner, @list), notice: 'List was successfully created.' }
         format.json { render :show, status: :created, location: @list }

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -23,7 +23,6 @@ class ListsController < ApplicationController
 
     respond_to do |format|
       if @list.save
-        current_user.lists << @list
         current_user.homepage.lists << @list
         format.html { redirect_to user_list_path(@list.owner, @list), notice: 'List was successfully created.' }
         format.json { render :show, status: :created, location: @list }

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -70,7 +70,11 @@
     <div class="form-group">
       <%= f.label :members, 'Add a contributor', class: "col-md-2 control-label"  %>
       <div class="col-md-10">
-        <% non_members = User.all - @list.members %>
+        <%
+          all_users = User.all
+          members = if list.persisted? then @list.members else [current_user] end
+          non_members = all_users - members
+        %>
         <%= f.select :members, non_members.map(&:username), {include_blank: 'None'}, {class: "form-control", disabled: current_user.can_moderate?(list)}  %>
       </div>
     </div>


### PR DESCRIPTION
**Problem:** List#create would explode

**Solution:** Remove the duplicate ListMembership creation

**Complications:** Also actually creates listmemberships on List#create

**Feature Changelog:**

- Makes it not explode on list creation
- Disables selecting yourself to add as a contributor on create
- Enables creation of list memberships on create
