### PR TITLE
Prevents references from being added or destroyed if user cannot edit

### DIFF
--- a/app/controllers/references_controller.rb
+++ b/app/controllers/references_controller.rb
@@ -8,8 +8,13 @@ class ReferencesController < ApplicationController
 
   def create
     list = List.find(reference_params[:list_id])
+    list_path = user_list_path(list.owner, list)
 
-    return redirect_to(:back, alert: @locator.errors.join(' ')) unless @locator.valid?
+    unless current_user.can_edit? list
+      return redirect_back(fallback_location: list_path, alert: 'You must be a contributor to make changes to this list.')
+    end
+
+    return redirect_back(fallback_location: list_path, alert: @locator.errors.join(' ')) unless @locator.valid?
 
     if (paper = @locator.find_or_import_paper)
       if Reference.exists? list_id: list.id, paper_id: paper.id
@@ -22,11 +27,16 @@ class ReferencesController < ApplicationController
       logger.debug "No paper found for: #{paper_params.inspect}"
       flash['alert'] = "Couldn't find or import a paper with those parameters"
     end
-    redirect_to :back
+    redirect_back(fallback_location: list_path)
   end
 
   def destroy
     reference = Reference.find(reference_params[:id])
+
+    unless current_user.can_edit? reference.list
+      return redirect_back(fallback_location: user_list_path(reference.list.owner, reference.list), alert: 'You must be a contributor to make changes to this list.')
+    end
+
     reference.destroy
 
     respond_to do |format|

--- a/app/views/papers/_abstract.html.erb
+++ b/app/views/papers/_abstract.html.erb
@@ -15,7 +15,7 @@
   <div class='abstract-form hidden'>
     <%= render 'papers/abstract_form', paper: paper %>
   </div>
-<% elsif current_user %>
+<% elsif current_user && current_user.can_edit?(reference.list) %>
   <b>No abstract found, you can add one:</b>
   <%= render 'papers/abstract_form', paper: paper %>
 <% else %>

--- a/app/views/papers/_tablist.html.erb
+++ b/app/views/papers/_tablist.html.erb
@@ -9,7 +9,7 @@
       <%= form_for reference, method: :delete do |r| %>
         <%= r.text_field :id, value: reference.id, hidden: true %>
       <% end %>
-      <%= link_to 'Remove from list', {}, class: 'delete-reference text-danger' %>
+      <%= link_to('Remove from list', {}, class: 'delete-reference text-danger') if current_user.can_edit?(reference.list) %>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
**Problem:** An unauthorized user could add and remove references to another user's list

**Solution:** Prevent unauthorized users from adding or removing references on another user's list

**Complications:** Not sure if I got all the cases

**Feature Changelog:**

- Prevent unauthorized users from adding or removing references on another user's list