### PR TITLE
Requires moderator permissions to delete comments

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -51,7 +51,15 @@ class CommentsController < ApplicationController
   # DELETE /comments/1.json
   def destroy
     reference = @comment.root.commentable
+    list = reference.list
+
+    unless current_user.can_moderate?(list)
+      flash[:alert] = "You do not have permission to moderate this list"
+      return redirect_back(fallback_location: user_list_path(list.owner, list))
+    end
+
     @comment.destroy
+
     respond_to do |format|
       format.html { redirect_to :back, notice: 'Comment was successfully destroyed.' }
       format.json { head :no_content }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -35,6 +35,11 @@ class CommentsController < ApplicationController
   # PATCH/PUT /comments/1
   # PATCH/PUT /comments/1.json
   def update
+    unless @comment.user == current_user
+      flash[:alert] = "You do not have permission to edit this comment"
+      redirect_back(fallback_location: user_list_path(list.owner, list))
+    end
+
     respond_to do |format|
       if @comment.update(comment_params)
         format.html { redirect_to :back, notice: 'Comment was successfully updated.' }
@@ -53,9 +58,9 @@ class CommentsController < ApplicationController
     reference = @comment.root.commentable
     list = reference.list
 
-    unless current_user.can_moderate?(list)
+    unless current_user.can_moderate?(list) || @comment.user == current_user
       flash[:alert] = "You do not have permission to moderate this list"
-      return redirect_back(fallback_location: user_list_path(list.owner, list))
+      redirect_back(fallback_location: user_list_path(list.owner, list))
     end
 
     @comment.destroy

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,10 +1,10 @@
 module CommentsHelper
-  def comments_tree_for(comments)
+  def comments_tree_for(comments, list)
     comments.map do |comment, nested_comments|
-      render 'comments/comment', comment: comment do
+      render 'comments/comment', comment: comment, list: list do
         content_tag(
           :div,
-          comments_tree_for(nested_comments),
+          comments_tree_for(nested_comments, list),
           class: "comments",
           'data-commentable-id' => comment.id
         )

--- a/app/helpers/lists_helper.rb
+++ b/app/helpers/lists_helper.rb
@@ -1,2 +1,13 @@
 module ListsHelper
+  def current_user_can_moderate? list
+    current_user && current_user.can_moderate?(list)
+  end
+
+  def current_user_can_edit? list
+    current_user && current_user.can_edit?(list)
+  end
+
+  def current_user_can_view? list
+    current_user && current_user.can_view?(list)
+  end
 end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -53,7 +53,7 @@ class List < ApplicationRecord
         owner_membership.update_column(:role, :moderator)
       end
 
-      list_memberships.find_by(user: user).update_column :role, :owner
+      list_memberships.find_or_create_by(user: user).update_column :role, :owner
     end
   end
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,8 +9,10 @@
     <li><%= render 'votes/toggle_like', votable: comment %></li>
     <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
     <% if current_user == comment.user %>
+      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
       <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
-      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "btn btn-link btn-xs", method: :delete %><li>
+    <% elsif current_user_can_moderate?(list) %>
+      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
     <% end %>
   </ul>
   <%= render('comments/form', comment: comment.children.build, hidden: true) if current_user %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -9,8 +9,8 @@
     <li><%= render 'votes/toggle_like', votable: comment %></li>
     <li><%= (link_to 'reply', "#", class: 'toggle-reply btn btn-link btn-xs', 'data-parent-comment-id' => comment.id) if current_user %></li>
     <% if current_user == comment.user %>
-      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
       <li><%= link_to 'edit', edit_comment_path(comment), remote: true, class: "edit-comment btn btn-link btn-xs" %></li>
+      <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
     <% elsif current_user_can_moderate?(list) %>
       <li><%= link_to 'delete', comment_path(comment), remote: true, class: "text-danger small", method: :delete %><li>
     <% end %>

--- a/app/views/comments/destroy.js.erb
+++ b/app/views/comments/destroy.js.erb
@@ -4,3 +4,5 @@ $("#comment-<%= @comment.id %>").remove();
 commentsCountSpan = $("span#comments-count-<%= reference.id %>");
 commentsCount = parseInt(commentsCountSpan.text());
 commentsCountSpan.text(parseInt(commentsCount - deletedComments));
+
+<%= render 'layouts/flash_messages', flash: {notice: 'Comment deleted.'} %>

--- a/app/views/comments/update.js.erb
+++ b/app/views/comments/update.js.erb
@@ -1,2 +1,4 @@
 commentContent = $("#comment-<%= @comment.id %> > .content")
 commentContent.html("<%= simple_format(@comment.content, {}, sanitize: true) %>")
+editLink = $("#comment-<%= @comment.id %>").find("a.edit-comment").first()
+editLink.parent('li').toggleClass('hidden', false);

--- a/app/views/crossref/_search.html.erb
+++ b/app/views/crossref/_search.html.erb
@@ -2,7 +2,13 @@
 <div class="input-group input-group-sm crossref">
 
   <span class="input-group-addon" id="crossref-submit"><i class="glyphicon glyphicon-search"></i></span>
-  <%= text_field_tag 'crossref-search', nil, class: 'form-control', placeholder: 'Search for a paper' %>
+  <%=
+    text_field_tag 'crossref-search',
+      nil,
+      class: 'form-control',
+      placeholder: 'Search for a paper',
+      disabled: !current_user_can_edit?(list)
+  %>
   <%= form_for list.references.build, html: {class: 'hidden'} do |f| %>
     <%= f.hidden_field :list_id, value: list.id %>
     <%= f.fields_for Paper.new do |p| %>

--- a/app/views/layouts/_flash_messages.js.erb
+++ b/app/views/layouts/_flash_messages.js.erb
@@ -1,0 +1,7 @@
+<% if flash[:notice] %>
+  $('div.flash-messages').append("<%= escape_javascript content_tag(:p, flash[:notice], class: 'notice alert-success') %>")
+<% end %>
+
+<% if flash[:alert] %>
+  $('div.flash-messages').append("<%= escape_javascript content_tag(:p, flash[:alert], class: 'alert alert-danger') %>")
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,11 +30,10 @@
         </div>
       </div>
     </nav>
-    <% if notice %>
-      <p class="notice alert-success"><%= notice %></p>
-    <% elsif alert %>
-      <p class="alert alert-danger"><%= alert %></p>
-    <% end %>
+    <div class="flash-messages">
+      <%= content_tag(:p, notice, class: "notice alert-success") if notice %>
+      <%= content_tag(:p, alert, class: "alert alert-danger") if alert %>
+    </div>
     <%= yield %>
     <%= console if Rails.env.development? %>
   </body>

--- a/app/views/lists/_add_reference.html.erb
+++ b/app/views/lists/_add_reference.html.erb
@@ -20,7 +20,7 @@
                           class: "form-control hidden paper-title input-sm",
                           disabled: true %>
         <div class="form-group">
-        <%= f.submit "Submit", class: "btn btn-primary btn-xs hidden", id: 'add_locator_submit' %>
+        <%= f.submit "Submit", class: "btn btn-primary btn-xs hidden", id: 'add_locator_submit', disabled: !current_user_can_edit?(list) %>
         <%= link_to "cancel", '#', id: "cancel-add-locator", class: "hidden" %>
         </div>
       </div>

--- a/app/views/lists/_form.html.erb
+++ b/app/views/lists/_form.html.erb
@@ -52,7 +52,7 @@
             <% members.each do |member| %>
               <div class="form-control contributor-list">
                 <%= link_to member.username, user_lists_path(member) %>
-                <% if current_user && @current_user.can_moderate?(list) || member == current_user %>
+                <% if current_user_can_moderate?(list) || member == current_user %>
                   <%= link_to('Remove',
                         list_member_path(list.id, member.id),
                         class: "remove-member text-danger pull-right",

--- a/app/views/papers/_abstract.html.erb
+++ b/app/views/papers/_abstract.html.erb
@@ -1,6 +1,6 @@
 <% paper = reference.paper %>
 
-<% if paper.abstract.present? %>
+<% if current_user && paper.abstract.present? %>
   <div class='edit-abstract' id="edit-abstract-<%=reference.id%>">
     <i class='help-block'>
       <% if paper.abstract_editable %>
@@ -15,7 +15,7 @@
   <div class='abstract-form hidden'>
     <%= render 'papers/abstract_form', paper: paper %>
   </div>
-<% elsif current_user && current_user.can_edit?(reference.list) %>
+<% elsif current_user_can_edit?(reference.list) %>
   <b>No abstract found, you can add one:</b>
   <%= render 'papers/abstract_form', paper: paper %>
 <% else %>

--- a/app/views/references/_comments.html.erb
+++ b/app/views/references/_comments.html.erb
@@ -8,6 +8,6 @@
 
 <div class="reference comments" data-commentable-id="<%= reference.id %>">
   <% reference.comments.order('cached_votes_up DESC, created_at ASC').each do |comment| %>
-    <%= comments_tree_for comment.hash_tree %>
+    <%= comments_tree_for comment.hash_tree, reference.list %>
   <% end %>
 </div>


### PR DESCRIPTION
**Problem:** Non-moderator users can delete comments

**Solution:** Prevent them from doing so

**Complications:** Caught a bunch of other minor things, too. Ended up screwing up a rebase, too, so I'm taking this opportunity to try squashing my commit history as well.

**Feature Changelog:**

- Prevents a user from deleting comments or adding contributors unless they're a moderator
- Disables paper search bar and add paper unless the user can edit the list
- Prevents a user from adding an abstract unless they're logged in
- Allows a user to moderate their own comment
- Prevents moderator from editing others' comments
