### PR TITLE
Only shows lists that the params user owns

### DIFF
--- a/app/controllers/users/lists_controller.rb
+++ b/app/controllers/users/lists_controller.rb
@@ -49,7 +49,9 @@ class Users::ListsController < ApplicationController
     end
 
     def set_list
-      @list = @user.lists.find_by slug: params[:id]
+      @list = @user.owned_lists.find_by slug: params[:id]
+
+      return redirect_back(fallback_location: lists_path, alert: "List not found.") unless @list
     end
 
     def params_sort_order

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,10 @@ class User < ApplicationRecord
     public_lists.or(shared_guest_lists)
   end
 
+  def owned_lists
+    lists.where('list_memberships.role' => :owner).uniq
+  end
+
   before_save { self.email.downcase! if self.email }
   after_create :create_homepage
 

--- a/app/views/lists/show.html.erb
+++ b/app/views/lists/show.html.erb
@@ -1,6 +1,6 @@
 <h2 class= "list-title"><%= @list.name %></h2>
 <div class="list-nav">
-  created by <%= link_to @list.owner.username, user_lists_path(@list.owner) %>
+  by <%= link_to @list.owner.username, user_lists_path(@list.owner) %>
   <% if current_user %>
     <% if current_user.can_edit? @list %>
      - <%= link_to 'Edit', edit_user_list_path(@list.owner, @list) %>


### PR DESCRIPTION
**Problem:**
Routes to lists were resolving for any user who had a membership, so `briankung/maintaining-mobility-in-old-age` lead to the same list as `testuser/maintaining-mobility-in-old-age`

**Solution:** Limit `users/lists#show` to lists that the user actually owns

**Complications:** I'm sure this will be a continuing headache to manage

**Feature Changelog:**

- Limit showing lists that the user in the url params actually owns
