### PR TITLE
Simplifies resources

### DIFF
--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -8,7 +8,8 @@ class Pubmed
     end
 
     def paper_attributes
-      @paper_attributes ||= map_attributes mapper(), Nokogiri::XML(response.try(:body), &:noblanks)
+      return nil if response.nil?
+      @paper_attributes ||= map_attributes mapper(), Nokogiri::XML(response.body, &:noblanks)
     end
 
     def map_attributes mapper, data
@@ -39,7 +40,12 @@ class Pubmed
 
     def get_response uid
       return nil if uid.nil?
-      Pubmed::Http.efetch(id: uid)
+      # Pubmed responds with <PubmedArticleSet></PubmedArticleSet> for IDs like 123456789987654321
+      # Check that the response size is larger than that + the doctype declaration
+      response = Pubmed::Http.efetch(id: uid)
+      return nil if response.body.size < 300
+
+      response
     end
   end
 end

--- a/app/models/services/pubmed/resource.rb
+++ b/app/models/services/pubmed/resource.rb
@@ -29,7 +29,7 @@ class Pubmed
         pubmed_id:          lambda {|data| data.css('PMID').text },
         abstract:           lambda do |data|
           data.css('AbstractText').map do |a|
-            a['Label'] + "\n" + a.text
+            if a['Label'] then "#{a['Label']}\n#{a.text}" else a.text end
           end.join("\n\n")
         end,
         abstract_editable:  lambda {|data| data.css('AbstractText').blank? },


### PR DESCRIPTION
**Problem:** Bugs and refactoring

**Solution:** Fix the bugs, refactor

**Complications:** This was in the hopes of implementing limited link scraping, but it ended up not being worth it in my opinion:

> We need to know what links we need to be able to scrape before we can decide which ones to scrape or how to do it

> so basically...maybe we let people input crap data for a little bit until we know what to prioritize

**Feature Changelog:**

- Bugfix: Guards against nil labels
- Bugfix: Guards against empty PubmedArticleSet for locator_ids like 1234567890987654321

