### PR TITLE
Remote delete bug

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,11 +28,19 @@ class ApplicationController < ActionController::Base
     store_location_for(:user, request.fullpath) unless user_paths.include?(request.path)
   end
 
+  def ajax_redirect_to(redirect_uri)
+    render js: "window.location.replace('#{redirect_uri}');"
+  end
+
   private
     def ensure_current_user
       unless current_user
         flash[:alert] = 'You must sign in to perform this action'
-        redirect_to new_user_session_path
+
+        respond_to do |format|
+          format.html { return redirect_to new_user_session_path }
+          format.js { return ajax_redirect_to(new_user_session_path) }
+        end
       end
     end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -58,17 +58,18 @@ class CommentsController < ApplicationController
     reference = @comment.root.commentable
     list = reference.list
 
-    unless current_user.can_moderate?(list) || @comment.user == current_user
-      flash[:alert] = "You do not have permission to moderate this list"
-      redirect_back(fallback_location: user_list_path(list.owner, list))
-    end
-
-    @comment.destroy
-
     respond_to do |format|
-      format.html { redirect_to :back, notice: 'Comment was successfully destroyed.' }
-      format.json { head :no_content }
-      format.js { render 'destroy.js.erb', locals: {reference: reference} }
+      if current_user.can_moderate?(list) || @comment.user == current_user
+        @comment.destroy
+        format.html { redirect_to :back, notice: 'Comment was successfully destroyed.' }
+        format.json { head :no_content }
+        format.js { render 'destroy.js.erb', locals: {reference: reference} }
+      else
+        flash[:alert] = 'You do not have permission to moderate this list.'
+
+        format.html { redirect_back fallback_location: user_list_path(list.owner, list) }
+        format.js { ajax_redirect_to(user_list_path(list.owner, list)) }
+      end
     end
   end
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -3,14 +3,27 @@ class LinksController < ApplicationController
 
   def destroy
     link = Link.find(link_params[:id])
-    url = link.url
-    paper = link.paper.title
-    link.destroy
-
     reference = Reference.find(params[:reference])
+    list = reference.list
+
     respond_to do |format|
-      format.html { redirect_back(fallback_location: root_path, notice: "'#{url}' has been successfully removed from '#{paper}'") }
-      format.js { render('destroy.js.erb', locals: { reference: reference }) }
+      list_path = user_list_path(list.owner, list)
+
+      if current_user.can_moderate?(list)
+        link.destroy
+        format.html do
+            redirect_back(
+              fallback_location: list_path,
+              notice: "'#{link.url}' has been successfully removed from '#{link.paper.title}'"
+            )
+        end
+        format.js { render('destroy.js.erb', reference: reference) }
+      else
+        flash[:alert] = 'You do not have permission to moderate this list.'
+
+        format.html { redirect_back(fallback_location: list_path) }
+        format.js { ajax_redirect_to(list_path) }
+      end
     end
   end
 

--- a/app/views/links/_links.html.erb
+++ b/app/views/links/_links.html.erb
@@ -12,7 +12,7 @@
   <% paper.links.each do |l| %>
     <li>
       <%= link_to l.url, l.url, target: '_blank' %>
-      <% if l.link_editable %>
+      <% if l.link_editable && current_user_can_moderate?(reference.list) %>
         <%= link_to '',
           link_path(l, reference: reference),
           method: 'delete',
@@ -20,8 +20,6 @@
           data: { confirm: 'Are you want to delete this link?' },
           remote: true
         %>
-      <% else %>
-      <i> - imported</i>
       <% end %>
     </li>
   <% end %>


### PR DESCRIPTION
**Problem:** Remote deletes would trigger redirect loops

**Solution:** Respond with js redirect. Also limits link deletion to moderators

**Complications:** Seems kind of hacky. Is hacky.

**Feature Changelog:**

- Limits ability to delete links to moderators
- Prevents remote delete redirect loops
