### PR TITLE
Makes sponsor us a link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
         </div>
         <div class="collapse navbar-collapse" id="navbar-collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li><%= button_to 'Sponsor Us','https://www.patreon.com/projectcredo', class: 'btn btn-default navbar-btn', target: '_blank' %></li>
+            <li class="active"><%= link_to 'Sponsor Us','https://www.patreon.com/projectcredo', target: '_blank' %></li>
             <%= render 'layouts/user_session_links' %>
           </ul>
         </div>


### PR DESCRIPTION
**Problem:** The sponsor us button wasn't working

**Solution:** Make it a link

**Complications:** Its list element is "active" so it sticks out, but it's kind of ugly

**Feature Changelog:**

- "Sponsor Us" button works now
