### PR TITLE
Removes new list links from user lists page

### DIFF
--- a/app/views/users/lists/index.html.erb
+++ b/app/views/users/lists/index.html.erb
@@ -5,13 +5,7 @@
   <small>sorted by popularity</small>
 </h1>
 
-<p><%= link_to 'Create New List', new_list_path %></p>
 <div class="cards row">
   <%= render partial: 'lists/list', collection: @lists %>
 </div>
 
-<div class="row">
-  <div class="col-md-12">
-    <%= link_to 'Create New List', new_list_path %>
-  </div>
-</div>


### PR DESCRIPTION
**Problem:** Create new list links on user list page doesn't really make any sense

**Solution:** Remove them

**Complications:**

**Feature Changelog:**

- Remove create new list links on user list page
