### PR TITLE
Improves slug function to handle punctuation at the beginning or end …

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -59,7 +59,7 @@ class List < ApplicationRecord
   end
 
   def to_slug
-    self.name.downcase.gsub("'", '').gsub(/[^\p{N}\p{L}]/, '-').gsub(/-{2,}/, '-')
+    self.name.downcase.gsub("'", '').scan(/[\p{N}\p{L}]{1,}/).join('-')
   end
 
   def set_slug


### PR DESCRIPTION
**Problem:** Slugs formed from titles like "Do cellphones cause cancer?" ended in hyphens.

**Solution:** Improve the slugs method.

**Complications:** It's changed drastically enough so that I'm not sure what other edge cases will pop up from it. Hopefully it should be fine.

**Feature Changelog:**

- Fix sluggification